### PR TITLE
feat: add Steem HARI-RAID to third-party games

### DIFF
--- a/components/games/Config.ts
+++ b/components/games/Config.ts
@@ -38,6 +38,23 @@ export const THIRD_PARTY_GAMES: Game[] = [
       website: "https://steempro.com/@stmpak.wit",
     },
   },
+  {
+    id: "steem-hari-raid",
+    title: "Steem HARI-RAID",
+    description:
+      "Summon elemental battle cards, raid weekly boss monsters with other players, and earn real STEEM rewards in this Tap2Earn crypto game.",
+    image:
+      "https://steemitimages.com/640x0/https://cdn.steemitimages.com/DQmPCwz9KvoHNnUsA3KSkA2cpMzQqJrrU3nAoypQp35QNsQ/main_4000.jpg",
+    category: "Strategy",
+    difficulty: "Easy",
+    href: "https://hari-raid.h4lab.com",
+    usesBlockchain: true,
+    stats: { rewards: "Active" },
+    developer: {
+      name: "H4LAB",
+      website: "http://h4lab.com/",
+    },
+  },
 ];
 
 export const CATEGORIES = [


### PR DESCRIPTION
- Add Steem HARI-RAID (by H4LAB) to the THIRD_PARTY_GAMES list in Config.ts
- Add H4LAB's Tap2Earn crypto game where players summon elemental battle cards and raid weekly boss monsters to earn STEEM rewards.
- Tap2Earn crypto game: summon elemental battle cards, raid weekly boss monsters, earn STEEM rewards
- Category: Strategy, Difficulty: Easy